### PR TITLE
Fixing the download_models script name

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ We provide several shell scripts for easy managing the experiments. (See
 
    ```sh
    # Download the pretrained models
-   ./scripts/download_pretrained_models.sh
+   ./scripts/download_models.sh
    ```
 
    You can also download the pretrained models manually


### PR DESCRIPTION
I plan on using musegan in my bachelor thesis, and when setting up my development environment i noticed this typo.